### PR TITLE
Add BugMapper class for converting between DTOs and Bug entities

### DIFF
--- a/src/main/java/org/example/bugtrackerlabjuv25g/BugMapper.java
+++ b/src/main/java/org/example/bugtrackerlabjuv25g/BugMapper.java
@@ -1,0 +1,39 @@
+package org.example.bugtrackerlabjuv25g;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+public class BugMapper {
+    //Convert CreateBugDTO to BugEntity
+    public Bug toEntity(CreateBugDTO createBugDTO) {
+        Bug bug = new Bug();
+        bug.setTitle(createBugDTO.title());
+        bug.setDescription(createBugDTO.description());
+        bug.setPriority(createBugDTO.priority());
+        bug.setDeveloperArea(createBugDTO.developerArea());
+        bug.setBugDate(LocalDateTime.now());
+
+        return bug;
+    }
+
+    //From Entity to DTO for show
+    public BugDTO toDTO(Bug bug) {
+        return new BugDTO(
+                bug.getId(),
+                bug.getTitle(),
+                bug.getDescription(),
+                bug.getBugDate(),
+                bug.getPriority(),
+                bug.getDeveloperArea()
+        );
+    }
+
+    public void updateBug(UpdateBugDTO updateBugDTO, Bug bug) {
+        bug.setTitle(updateBugDTO.title());
+        bug.setDescription(updateBugDTO.description());
+        bug.setPriority(updateBugDTO.priority());
+        bug.setDeveloperArea(updateBugDTO.developerArea());
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `BugMapper` class to the codebase, which centralizes the logic for converting between bug-related DTOs and entities. This addition improves code organization and maintainability by separating data mapping concerns.

Data mapping enhancements:

* Added the `BugMapper` class in `src/main/java/org/example/bugtrackerlabjuv25g/BugMapper.java` to handle conversions between `CreateBugDTO`, `Bug`, `BugDTO`, and `UpdateBugDTO`.
* Implemented methods for mapping from `CreateBugDTO` to `Bug` entity, from `Bug` entity to `BugDTO`, and for updating a `Bug` entity using `UpdateBugDTO`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved the bug tracking system's data management infrastructure with enhanced transformation and update mechanisms. Bug record operations—including creation, conversion, and modifications—now benefit from more consistent and reliable handling, strengthening overall data integrity and establishing robust foundations for comprehensive bug tracking capabilities across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->